### PR TITLE
Support gnome-shell 3.6

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
      "kagesenshi.87@gmail.com"
   ],
   "shell-version": [
-     "3.2", "3.5.2"
+     "3.2", "3.5.2", "3.6"
   ],
   "url": "https://github.com/kagesenshi/gnome-shell-extension-stealmyfocus",
   "uuid": "steal-my-focus@kagesenshi.org",


### PR DESCRIPTION
I declared in the manifest support for gnome-shell 3.6.

I tested that the extension works under Fedora 18, gnome-shell 3.6.3 using pidgin ( with the Message Notification plugin).
