### PR TITLE
Update metadata.json for v3.8, v3.10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
      "kagesenshi.87@gmail.com"
   ],
   "shell-version": [
-     "3.2", "3.5.2"
+     "3.2", "3.5.2", "3.8", "3.10"
   ],
   "url": "https://github.com/kagesenshi/gnome-shell-extension-stealmyfocus",
   "uuid": "steal-my-focus@kagesenshi.org",


### PR DESCRIPTION
Added gnome-shell versions ("3.8", "3.10") to metadata.json
