### PR TITLE
Support gnome shell 3.16 and 3.18

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,9 @@
     "3.6",
     "3.8",
     "3.10",
-    "3.10.*"
+    "3.10.*",
+    "3.16",
+    "3.18"
   ],
   "url": "https://github.com/kagesenshi/gnome-shell-extension-stealmyfocus",
   "uuid": "steal-my-focus@kagesenshi.org",


### PR DESCRIPTION
Works for both (used gnome 3.16 before and now using 3.18)
